### PR TITLE
ci: Add CI for voms-atlas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       with:
         repository: kratsg/voms-atlas
         dockerfile: voms-atlas/Dockerfile
+        path: voms-atlas
         tags: test
         tag_with_sha: true
         tag_with_ref: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  schedule:
+  - cron:  '1 0 * * 0'
+
+jobs:
+  test-voms-atlas:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build Docker image
+      if: "!(startsWith(github.ref, 'refs/tags/'))"
+      uses: docker/build-push-action@v1
+      with:
+        repository: kratsg/voms-atlas
+        dockerfile: voms-atlas/Dockerfile
+        tags: test
+        tag_with_sha: true
+        tag_with_ref: true
+        push: false
+    - name: List Built Images
+      run: docker images

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,7 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: kratsg/voms-atlas
         dockerfile: voms-atlas/Dockerfile
+        path: voms-atlas
         tags: latest
     - name: Build and Publish to Registry with Release Tag
       if: startsWith(github.ref, 'refs/tags/')
@@ -30,5 +31,6 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: kratsg/voms-atlas
         dockerfile: voms-atlas/Dockerfile
+        path: voms-atlas
         tags: latest,latest-stable
         tag_with_ref: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+name: Publish Docker Images
+
+on:
+  push:
+    branches:
+    - master
+    tags:
+    - v*
+
+jobs:
+  publish-voms-atlas:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+    - name: Build and Publish to Registry
+      if: "!(startsWith(github.ref, 'refs/tags/'))"
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: kratsg/voms-atlas
+        dockerfile: voms-atlas/Dockerfile
+        tags: latest
+    - name: Build and Publish to Registry with Release Tag
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: kratsg/voms-atlas
+        dockerfile: voms-atlas/Dockerfile
+        tags: latest,latest-stable
+        tag_with_ref: true


### PR DESCRIPTION
This PR adds CI for `kratsg/voms-atlas` but could be expanded to other images. For this to work the GitHub secrets `DOCKER_USERNAME ` and `DOCKER_PASSWORD` need to be set.

```
* Add CI to test and publish builds of kratsg/voms-atlas
   - Uses docker/build-push-action@v1 API, not current v2 API
```